### PR TITLE
build: Fix release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 node_modules
-cypress
 docker-compose.yaml
 Dockerfile


### PR DESCRIPTION
The `cypress` folder needs to be included in order to allow `typescript` to infer the `cypress` types in the build stage. 